### PR TITLE
Исправлен сдвиг кнопки при hover/focus

### DIFF
--- a/src/sass/layouts/_hero.scss
+++ b/src/sass/layouts/_hero.scss
@@ -347,7 +347,7 @@
 }
 
 .bttn {
-  border: transparent;
+  border: 1px solid transparent;
   border-radius: 20px;
   outline: none;
 


### PR DESCRIPTION
При состоянии hover/focus кнопка незначительно сдвигалась.

Для исправления ситуации добавлено дополнительное значение для кнопки в обычном состоянии.
Было
border: transparent;
стало
border: 1px solid transparent;

Таким образом при значении hover/focus
border: 1 px solid $color***;
сдвига не происходит.