### PR TITLE
изменила высоту мобильного иеню и почистила код

### DIFF
--- a/src/sass/layouts/_header.scss
+++ b/src/sass/layouts/_header.scss
@@ -1,10 +1,10 @@
 .page-header {
- 
-  background-color: transparent;
+  background-color:transparent;
     position: fixed;
     width: 100%;
     top: 0;
-    z-index: 500;}
+    z-index: 500;
+    }
     
 
  .header__container {
@@ -13,6 +13,9 @@
     justify-content: space-between;
     align-items: center;
     padding-top: 6px;
+    @media screen and (max-width: 768px) {
+      
+    }
     
     @media screen and (min-width: 768px) {
       padding-top: 37px;
@@ -28,16 +31,13 @@
    @media screen and (min-width: 768px) {
   display: inline-flex;
     align-items: center;
-    justify-content: space-between;
 }}
 
 //  переключатель мобильного меню
 
 .menu-button {
     z-index: 1100;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+     display: flex;
     padding: 0;
     margin: 0;
     border: 0;
@@ -83,28 +83,22 @@
 // оформлени позиционирования ссылок и кнопки купить в  мобильной и десктопной версии
  
 .menu__container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
     transition: opacity $transition-duration $timing-function,
       visibility $transition-duration $timing-function;
     @media screen and (max-width: 1279px) {
       z-index: 800;
       position: absolute;
+      height: 100vh;
       top: 0;
       right: 0;
       opacity: 0;
       visibility: hidden;
       background-color: $pink-bg-secondary;
       width: 250px;
-      height: 502px;
       padding-top: 60px;
-      padding-bottom: 152px;
       padding-left: 21px;
-      padding-right: 21px;
+      flex-direction: column;
  @media screen and (min-width: 768px) and (max-width: 1279px) {
-      height: 100vh;
-       padding-bottom: 669px;
         padding-left: 24px;
       padding-right: 24px;
     }}
@@ -113,11 +107,7 @@
         visibility: visible;
       }
   }
-  .navigation {
-    @media screen and (max-width: 1279px){
-     width: 100%;
-   }
-  }
+  
     // Оформление стилей шрифта, внешних отступов для ссылок в меню
 .menu {
   @include font (700, 14px, 1.29);
@@ -132,10 +122,8 @@
     @media screen and (max-width: 1279px) {
       display: block;
       border-top: solid 1px #e18298;
-      &:not(:last-child) {
-        padding-top: 11px;
+       padding-top: 11px;
         padding-bottom: 12px;
-      }
       &:last-child {
         border-bottom: solid 1px #e18298;
       }
@@ -152,11 +140,6 @@
       &:focus {
         color:$primary-accent-color;
       }
-
-      // @media screen and (max-width: 1279px) {
-      //   padding-left: 21px;
-      //   padding-right:21px;
-      // }
 
       @media screen and (min-width: 1280px) {
         display: inline-block;


### PR DESCRIPTION
Для того чтоб сделать меню в мобильной версии справа, общему контейнеру нужно задать min-width 320px(так как хедер в релативе,а кнопка и меню позиционируется относительно хедера и  заданным координаторам (top и right),то когда контейнер с шириной 320px,меню не может выйти за пределы ширины 320px.
Скрипт не поняла как подключать, бекграунд рбг все равно отличается и заезжает на мороженое. Оставила хедер фиксированным.