### PR TITLE
Исправления в блоке retail секции Hero

### DIFF
--- a/src/sass/layouts/_hero.scss
+++ b/src/sass/layouts/_hero.scss
@@ -266,7 +266,7 @@
   }
 
   &__content {
-    padding-right: 20px;
+    
     background-repeat: no-repeat;
     background-position: top 0 right 0;
 
@@ -281,6 +281,7 @@
     }
 
     @media screen and (min-width: 1280px) {
+      margin-right: 20px;
       background-image: url(/images/desktop/hero-white-circle.png);
       background-size: 30px;
     }


### PR DESCRIPTION
В десктопной версии фоновый белый круг располагался в блоке не по макету. Изменен отступ с внутреннего на внешний.